### PR TITLE
Add option for raw md5 hash to be passed as src

### DIFF
--- a/src/angular-gravatar.coffee
+++ b/src/angular-gravatar.coffee
@@ -43,8 +43,8 @@ angular.module('ui.gravatar', ['md5'])
       # Look for gravatar options
       opts = filterKeys 'gravatar', attrs
       delete opts['src']
-      scope.$watch attrs.gravatarSrc, (email) ->
-        return unless email?
-        element.attr('src', gravatarService.url(email, opts))
+      scope.$watch attrs.gravatarSrc, (src) ->
+        return unless src?
+        element.attr('src', gravatarService.url(src, opts))
 
 ])


### PR DESCRIPTION
For privacy reasons, my API cannot expose emails publicly. I added a patch to your library so I can use md5 hashes directly as the source. Tell me if you find this useful and I will write the unit tests to cover the new feature.
